### PR TITLE
add configuration option for flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ Add the following variables into your base environment:
 }
 ```
 
+If you need to set any [global flags](https://developer.1password.com/docs/cli/reference/#global-flags), add the following:
+
+```json
+{
+  "__op_plugin": {
+    "flags": {
+      // For example specify the account to use
+      "account": "example.1password.com",
+    }
+  }
+}
+```
+
 ## Usage
 
 1. Hit `Ctrl + Space` and select the `1Password => Fetch Secret` action.

--- a/dist/app.js
+++ b/dist/app.js
@@ -92,6 +92,9 @@ var fetchSecretTemplateTag = {
                 switch (_a.label) {
                     case 0:
                         config = context.context[OP_PLUGIN_CONFIG_KEY];
+                        if (config === null || config === void 0 ? void 0 : config.flags) {
+                            (0, op_js_1.setGlobalFlags)(config.flags);
+                        }
                         return [4, checkCli(config === null || config === void 0 ? void 0 : config.cliPath)];
                     case 1:
                         _a.sent();

--- a/dist/cache.js
+++ b/dist/cache.js
@@ -3,22 +3,21 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.writeOpCliInstalled = exports.opCliInstalled = exports.getEntry = exports.writeEntry = void 0;
+exports.writeEntry = writeEntry;
+exports.getEntry = getEntry;
+exports.opCliInstalled = opCliInstalled;
+exports.writeOpCliInstalled = writeOpCliInstalled;
 var node_cache_1 = __importDefault(require("node-cache"));
 var cache = new node_cache_1.default({ stdTTL: 60 * 60 });
 function writeEntry(ref, value) {
     return cache.set(ref, value);
 }
-exports.writeEntry = writeEntry;
 function getEntry(ref) {
     return cache.get(ref);
 }
-exports.getEntry = getEntry;
 function opCliInstalled() {
     return cache.get('opCliInstalled');
 }
-exports.opCliInstalled = opCliInstalled;
 function writeOpCliInstalled(installed) {
     return cache.set('opCliInstalled', installed);
 }
-exports.writeOpCliInstalled = writeOpCliInstalled;

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 
 type PluginConfig = {
   cliPath?: string;
-  flags?: {};
+  flags?: Record<string, any>;
 };
 
 const OP_PLUGIN_CONFIG_KEY = '__op_plugin';

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,11 @@
-import { validateCli, read } from '@1password/op-js';
+import { validateCli, read, setGlobalFlags } from '@1password/op-js';
 import * as cache from './cache';
 import path from 'path';
 import fs from 'fs';
 
 type PluginConfig = {
   cliPath?: string;
+  flags?: {};
 };
 
 const OP_PLUGIN_CONFIG_KEY = '__op_plugin';
@@ -27,6 +28,10 @@ const fetchSecretTemplateTag = {
   ],
   async run(context: any, reference: string) {
     const config = context.context[OP_PLUGIN_CONFIG_KEY] as PluginConfig | undefined;
+
+    if (config?.flags) {
+      setGlobalFlags(config.flags);
+    }
 
     await checkCli(config?.cliPath);
     const entry = await fetchEntry(reference);


### PR DESCRIPTION
As I have two accounts in my 1Password vault, I couldn't receive any secrets.
So I added a “flags” config to configure [1Password global flags](https://developer.1password.com/docs/cli/reference/#global-flags).