### PR TITLE
Possibility to change the default TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Add the plugin config into your base environment (replace or remove the account 
   "__op_plugin": {
     "cliPath": "/opt/homebrew/bin/op",
     "defaultAccount": "team-name.1password.com",
+    
+    // Passwords are kept in memory for 3600 seconds (1 hour) by default. You can change this TTL here.
+    // To access passwords that are added to 1Password before the TTL expires you'll need to restart Insomnia.
+    "ttl": 3600,
 
     // If you need to set any global flags set them here.
     // For available flags, see https://developer.1password.com/docs/cli/reference/#global-flags
@@ -56,6 +60,8 @@ reference this variable inside the action.
 Due to the fact that Insomnia retrieves the values every time when you e.g. hover over a variable
 the plugin uses `node-cache` to cache secrets for one hour. If you want to purge the cache,
 restart Insomnia.
+
+You can change this default TTL by setting the `ttl` property in the plugin config. See [configuration](#configuration) section.
 
 ## Acknowledgements
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ type PluginConfig = {
   cliPath?: string;
   flags?: Record<string, any>;
   defaultAccount?: string;
+  ttl?: number;
 };
 
 const OP_PLUGIN_CONFIG_KEY = '__op_plugin';
@@ -44,14 +45,14 @@ const fetchSecretTemplateTag = {
       setGlobalFlags(config.flags);
     }
 
-    await checkCli(config?.cliPath);
-    const entry = await fetchEntry(reference, account ?? config?.defaultAccount);
+    await checkCli(config?.cliPath, config?.ttl);
+    const entry = await fetchEntry(reference, account ?? config?.defaultAccount, config?.ttl);
 
     return entry;
   },
 };
 
-async function checkCli(cliPath?: string) {
+async function checkCli(cliPath?: string, ttl?: number) {
   if (cache.opCliInstalled() !== true) {
     try {
       if (cliPath && !fs.existsSync(cliPath)) {
@@ -71,7 +72,7 @@ async function checkCli(cliPath?: string) {
 
       await validateCli();
 
-      cache.writeOpCliInstalled(true);
+      cache.writeOpCliInstalled(true, ttl);
     } catch (e: any) {
       const error = new Error(
         `There was an issue with the 1Password CLI. If you have the op CLI installed using e.g. Homebrew, please set the '__op_plugin.cliPath' environment variable to the directory containing the 'op' binary. (e.g. /opt/homebrew/bin/op). Error details: ${e.message}`,
@@ -84,7 +85,7 @@ async function checkCli(cliPath?: string) {
   }
 }
 
-async function fetchEntry(ref: string, account: string) {
+async function fetchEntry(ref: string, account: string, ttl?: number) {
   const existing = cache.getEntry(ref);
 
   if (existing) {
@@ -98,7 +99,7 @@ async function fetchEntry(ref: string, account: string) {
   }
 
   const entry = read.parse(ref, args);
-  cache.writeEntry(ref, entry);
+  cache.writeEntry(ref, entry, ttl);
 
   return entry;
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -2,7 +2,11 @@ import NodeCache from 'node-cache';
 
 const cache = new NodeCache({ stdTTL: 60 * 60 });
 
-export function writeEntry(ref: string, value: string | number) {
+export function writeEntry(ref: string, value: string | number, ttl?: number) {
+  if (typeof ttl === 'number') {
+    return cache.set(ref, value, ttl);
+  }
+
   return cache.set(ref, value);
 }
 
@@ -14,6 +18,10 @@ export function opCliInstalled() {
   return cache.get('opCliInstalled');
 }
 
-export function writeOpCliInstalled(installed: boolean) {
+export function writeOpCliInstalled(installed: boolean, ttl?: number) {
+  if (typeof ttl === 'number') {
+    return cache.set('opCliInstalled', installed, ttl);
+  }
+
   return cache.set('opCliInstalled', installed);
 }


### PR DESCRIPTION
Referring to https://github.com/benvp/insomnia-plugin-op/issues/1 and https://github.com/Kong/insomnia/issues/7260

My Insomnia is requesting my credentials every 60 minutes because the default TTL is set to 1 hour. This pops up at very annoying times.
I would rather keep my passwords in cache as long as Insomnia is running.

With introducing this option someone can choose to increase the TTL.